### PR TITLE
Update compatible to rv8803-catie

### DIFF
--- a/boards/shields/zest_rtc_rv-8803-c7/zest_rtc_rv8803-c7.overlay
+++ b/boards/shields/zest_rtc_rv-8803-c7/zest_rtc_rv8803-c7.overlay
@@ -12,18 +12,18 @@
 	&i2c_zest_rtc_rv8803_##port { \
 		status = "okay"; \
 		mfd_zest_rtc_rv8803_##port: rv8803##port@32 { \
-			compatible = "microcrystal,rv8803"; \
+			compatible = "microcrystal,rv8803-catie"; \
 			reg = <0x32>; \
 			irq-gpios = <&sixtron_connector_##port DIO2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; \
 			rtc_zest_rtc_rv8803_##port: rv8803-rtc##port { \
-				compatible = "microcrystal,rv8803-rtc"; \
+				compatible = "microcrystal,rv8803-rtc-catie"; \
 			}; \
 			counter_zest_rtc_rv8803_##port: rv8803-cnt##port { \
-				compatible = "microcrystal,rv8803-cnt"; \
+				compatible = "microcrystal,rv8803-cnt-catie"; \
 				frequency = "1"; \
 			}; \
 			clock_zest_rtc_rv8803_##port: rv8803-clk##port { \
-				compatible = "microcrystal,rv8803-clk"; \
+				compatible = "microcrystal,rv8803-clk-catie"; \
 				#clock-cells = <0>; \
 			}; \
 		}; \

--- a/boards/shields/zest_rtc_rv-8803-c7/zest_rtc_rv8803-c7_alt.overlay
+++ b/boards/shields/zest_rtc_rv-8803-c7/zest_rtc_rv8803-c7_alt.overlay
@@ -12,18 +12,18 @@
 	&i2c_zest_rtc_rv8803_##port { \
 		status = "okay"; \
 		mfd_zest_rtc_rv8803_##port: rv8803##port@32 { \
-			compatible = "microcrystal,rv8803"; \
+			compatible = "microcrystal,rv8803-catie"; \
 			reg = <0x32>; \
 			irq-gpios = <&sixtron_connector_##port irq_pin (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; \
 			rtc_zest_rtc_rv8803_##port: rv8803-rtc##port { \
-				compatible = "microcrystal,rv8803-rtc"; \
+				compatible = "microcrystal,rv8803-rtc-catie"; \
 			}; \
 			counter_zest_rtc_rv8803_##port: rv8803-cnt##port { \
-				compatible = "microcrystal,rv8803-cnt"; \
+				compatible = "microcrystal,rv8803-cnt-catie"; \
 				frequency = "1"; \
 			}; \
 			clock_zest_rtc_rv8803_##port: rv8803-clk##port { \
-				compatible = "microcrystal,rv8803-clk"; \
+				compatible = "microcrystal,rv8803-clk-catie"; \
 				#clock-cells = <0>; \
 			}; \
 		}; \


### PR DESCRIPTION
The rv8803 is now supported in Zephyr OS since v4.1.0. This pull request updates the device tree overlay for the `zest_rtc_rv-8803-c7` shield to use new compatible strings specific to a variant suffixed by "catie".

### Updates to compatible strings:

* Updated the `compatible` property for the `rv8803@32` node to `microcrystal,rv8803-catie` from `microcrystal,rv8803`.
* Updated the `compatible` property for the `rv8803-rtc` subnode to `microcrystal,rv8803-rtc-catie` from `microcrystal,rv8803-rtc`.
* Updated the `compatible` property for the `rv8803-cnt` subnode to `microcrystal,rv8803-cnt-catie` from `microcrystal,rv8803-cnt`.
* Updated the `compatible` property for the `rv8803-clk` subnode to `microcrystal,rv8803-clk-catie` from `microcrystal,rv8803-clk`.